### PR TITLE
Fix a bug in TSPLIB GEO coordinate conversion

### DIFF
--- a/SYMPHONY/Applications/VRP/src/Master/vrp_io.c
+++ b/SYMPHONY/Applications/VRP/src/Master/vrp_io.c
@@ -402,7 +402,7 @@ void vrp_io(vrp_problem *vrp, char *infile)
 	      deg = (int)(dist->coordx[node-1]);
 	      min = dist->coordx[node-1] - deg;
 	      dist->coordx[node-1] = MY_PI * (deg + 5.0*min/3.0 ) / 180.0;
-	      deg = floor(dist->coordy[node-1]);
+	      deg = (int)(dist->coordy[node-1]);
 	      min = dist->coordy[node-1] - deg;
 	      dist->coordy[node-1] = MY_PI * (deg + 5.0*min/3.0 ) / 180.0;
 	   }


### PR DESCRIPTION
The TSPLIB GEO point coordinates are in the format DEG.MMM, where the DEG is degrees and MMM angle minutes. Using a floor function causes the negative values to be interpreted incorrectly. Please note that fixing the issue changes the results in the files ulysses-n22-k4.opt and ulysses-n16-k3.opt in https://projects.coin-or.org/SYMPHONY/browser/html/branchandcut/VRP/data/V/ and these should be updated.